### PR TITLE
Refactor WeaponCollision

### DIFF
--- a/ValheimVRMod/Patches/CollisionPatches.cs
+++ b/ValheimVRMod/Patches/CollisionPatches.cs
@@ -229,9 +229,10 @@ namespace ValheimVRMod.Patches {
                 Quaternion.identity); // Quaternion.identity might need to be replaced
             ___m_hitTerrainEffect.Create(pos, Quaternion.identity);
 
-            if (___m_weapon.m_shared.m_spawnOnHitTerrain && MainWeaponCollision.isLastHitOnTerrain) {
+            MainWeaponCollision weaponCollision = Player.m_localPlayer.gameObject.GetComponentInChildren<MainWeaponCollision>();
+            if (___m_weapon.m_shared.m_spawnOnHitTerrain && weaponCollision.isLastHitOnTerrain) {
                 __instance.SpawnOnHitTerrain(pos, ___m_weapon.m_shared.m_spawnOnHitTerrain);
-                MainWeaponCollision.isLastHitOnTerrain = false;
+                weaponCollision.isLastHitOnTerrain = false;
             }
 
             if (___m_weapon.m_shared.m_useDurability && ___m_character.IsPlayer() && !AttackTargetMeshCooldown.durabilityDrained)

--- a/ValheimVRMod/Patches/CollisionPatches.cs
+++ b/ValheimVRMod/Patches/CollisionPatches.cs
@@ -229,9 +229,9 @@ namespace ValheimVRMod.Patches {
                 Quaternion.identity); // Quaternion.identity might need to be replaced
             ___m_hitTerrainEffect.Create(pos, Quaternion.identity);
 
-            if (___m_weapon.m_shared.m_spawnOnHitTerrain && WeaponCollision.isLastHitOnTerrain) {
+            if (___m_weapon.m_shared.m_spawnOnHitTerrain && MainWeaponCollision.isLastHitOnTerrain) {
                 __instance.SpawnOnHitTerrain(pos, ___m_weapon.m_shared.m_spawnOnHitTerrain);
-                WeaponCollision.isLastHitOnTerrain = false;
+                MainWeaponCollision.isLastHitOnTerrain = false;
             }
 
             if (___m_weapon.m_shared.m_useDurability && ___m_character.IsPlayer() && !AttackTargetMeshCooldown.durabilityDrained)

--- a/ValheimVRMod/Patches/ControlPatches.cs
+++ b/ValheimVRMod/Patches/ControlPatches.cs
@@ -657,9 +657,9 @@ namespace ValheimVRMod.Patches {
                     break;
                 
                 case EquipType.Tankard:
-                    if (MainWeaponCollision.isDrinking) {
+                    if (WeaponCollision.isDrinking) {
                         attack = true;
-                        MainWeaponCollision.isDrinking = false;
+                        WeaponCollision.isDrinking = false;
                     }
 
                     break;

--- a/ValheimVRMod/Patches/ControlPatches.cs
+++ b/ValheimVRMod/Patches/ControlPatches.cs
@@ -657,9 +657,9 @@ namespace ValheimVRMod.Patches {
                     break;
                 
                 case EquipType.Tankard:
-                    if (WeaponCollision.isDrinking) {
+                    if (MainWeaponCollision.isDrinking) {
                         attack = true;
-                        WeaponCollision.isDrinking = false;
+                        MainWeaponCollision.isDrinking = false;
                     }
 
                     break;

--- a/ValheimVRMod/Patches/EquipPatches.cs
+++ b/ValheimVRMod/Patches/EquipPatches.cs
@@ -90,7 +90,7 @@ namespace ValheimVRMod.Patches {
                 (meshFilter.gameObject.AddComponent<ThrowableManager>()).weaponWield = weaponWield;
             }
 
-            var weaponCol = StaticObjects.rightWeaponCollider().GetComponent<WeaponCollision>();
+            var weaponCol = StaticObjects.rightWeaponCollider().GetComponent<MainWeaponCollision>();
             weaponCol.setColliderParent(meshFilter.transform, ___m_rightItem, true);
             weaponCol.weaponWield = weaponWield;
             meshFilter.gameObject.AddComponent<ButtonSecondaryAttackManager>().Initialize(meshFilter.transform, ___m_rightItem, true);

--- a/ValheimVRMod/Scripts/AttackTargetMeshCooldown.cs
+++ b/ValheimVRMod/Scripts/AttackTargetMeshCooldown.cs
@@ -58,7 +58,7 @@ namespace ValheimVRMod.Scripts {
                 damageMultiplier /= 2;
             }
 
-            WeaponCollision weaponCollision = Player.m_localPlayer.gameObject.GetComponentInChildren<WeaponCollision>();
+            MainWeaponCollision weaponCollision = Player.m_localPlayer.gameObject.GetComponentInChildren<MainWeaponCollision>();
             if (weaponCollision && weaponCollision.twoHandedMultitargetSwipeCountdown > 0)
             {
                 return 1;

--- a/ValheimVRMod/Scripts/ButtonSecondaryAttackManager.cs
+++ b/ValheimVRMod/Scripts/ButtonSecondaryAttackManager.cs
@@ -455,7 +455,7 @@ namespace ValheimVRMod.Scripts
                     }
                     if (isTerrain)
                     {
-                        WeaponCollision.isLastHitOnTerrain = true;
+                        MainWeaponCollision.isLastHitOnTerrain = true;
                     }
                     outline.enabled = true;
                     outline.OutlineColor = new Color(1, 1, 0, 0.5f);

--- a/ValheimVRMod/Scripts/ButtonSecondaryAttackManager.cs
+++ b/ValheimVRMod/Scripts/ButtonSecondaryAttackManager.cs
@@ -455,7 +455,8 @@ namespace ValheimVRMod.Scripts
                     }
                     if (isTerrain)
                     {
-                        MainWeaponCollision.isLastHitOnTerrain = true;
+                        MainWeaponCollision weaponCollision = Player.m_localPlayer.gameObject.GetComponentInChildren<MainWeaponCollision>();
+                        weaponCollision.isLastHitOnTerrain = true;
                     }
                     outline.enabled = true;
                     outline.OutlineColor = new Color(1, 1, 0, 0.5f);

--- a/ValheimVRMod/Scripts/MainWeaponCollision.cs
+++ b/ValheimVRMod/Scripts/MainWeaponCollision.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.Rendering;
+using ValheimVRMod.Scripts.Block;
+using ValheimVRMod.Utilities;
+using ValheimVRMod.VRCore;
+using Valve.VR;
+
+namespace ValheimVRMod.Scripts {
+    public class MainWeaponCollision : WeaponCollision {
+        private const float MIN_STAB_SPEED = 1f;
+        private const float MAX_STAB_ANGLE = 30f;
+        private const float MAX_STAB_ANGLE_TWOHAND = 40f;
+
+        private Attack secondaryAttack;
+        private float postSecondaryAttackCountdown;
+        public LocalWeaponWield weaponWield;
+        public PhysicsEstimator mainHandPhysicsEstimator { get { return weaponWield.mainHand == VRPlayer.leftHand ? VRPlayer.leftHandPhysicsEstimator : VRPlayer.rightHandPhysicsEstimator; } }
+        public float twoHandedMultitargetSwipeCountdown { get; private set; } = 0;
+
+
+        protected override Attack tryHitTarget(AttackTargetMeshCooldown attackTargetMeshCooldown) {
+            bool isSecondaryAttack = postSecondaryAttackCountdown <= 0 && RoomscaleSecondaryAttackUtils.IsSecondaryAttack(this.physicsEstimator, this.mainHandPhysicsEstimator);
+            if (EquipScript.getRight() == EquipType.Polearms)
+            {
+                // Allow continuing an ongoing atgeir secondary attack (multitarget swipe) until cooldown finishes.
+                isSecondaryAttack = postSecondaryAttackCountdown > 0 || isSecondaryAttack;
+            }
+
+            Attack currentAttack;
+            if (isSecondaryAttack)
+            {
+                // Use the target cooldown time of the primary attack if it is shorter to allow a primary attack immediately after secondary attack;
+                // The secondary attack cooldown time is managed by postSecondaryAttackCountdown in this class intead.
+                float targetCooldownTime = Mathf.Min(WeaponUtils.GetAttackDuration(attack), WeaponUtils.GetAttackDuration(secondaryAttack));
+                bool attackSucceeded = attackTargetMeshCooldown.tryTriggerSecondaryAttack(targetCooldownTime);
+                if (!attackSucceeded)
+                {
+                    return null;
+                }
+                currentAttack = secondaryAttack;
+                if (postSecondaryAttackCountdown <= 0)
+                {
+                    postSecondaryAttackCountdown = WeaponUtils.GetAttackDuration(secondaryAttack);
+                }
+            }
+            else
+            {
+                currentAttack = base.tryHitTarget(attackTargetMeshCooldown);
+            }
+
+            if (currentAttack != null && WeaponUtils.IsTwoHandedMultitargetSwipe(currentAttack) && twoHandedMultitargetSwipeCountdown <= 0)
+            {
+                twoHandedMultitargetSwipeCountdown = WeaponUtils.GetAttackDuration(currentAttack);
+            }
+
+            return currentAttack;
+        }
+
+        protected override bool outlineTarget() {
+
+            if (!outline || ButtonSecondaryAttackManager.isSecondaryAttackStarted) {
+                return false;
+            }
+
+            bool outlineUpdatedForPrimaryAttack = base.outlineTarget();
+            if (outlineUpdatedForPrimaryAttack)
+            {
+                return true;
+            }
+
+            if (postSecondaryAttackCountdown > 0.5f) {
+                outline.enabled = true;
+                outline.OutlineColor = Color.Lerp(new Color(1, 1, 0, 0), new Color(1, 1, 0, 0.5f), postSecondaryAttackCountdown - 0.5f);
+                outline.OutlineWidth = 10;
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool isStab()
+        {
+            Vector3 attackVelocity = mainHandPhysicsEstimator == null ? Vector3.zero : mainHandPhysicsEstimator.GetAverageVelocityInSnapshots();
+
+            if (Vector3.Angle(LocalWeaponWield.weaponForward, attackVelocity) > (LocalWeaponWield.isCurrentlyTwoHanded() ? MAX_STAB_ANGLE_TWOHAND : MAX_STAB_ANGLE))
+            {
+                return false;
+            }
+
+            if (Vector3.Dot(attackVelocity, LocalWeaponWield.weaponForward) > MIN_STAB_SPEED)
+            {
+                LogUtils.LogDebug("VHVR: stab detected on weapon direction: " + LocalWeaponWield.weaponForward);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/ValheimVRMod/Scripts/MainWeaponCollision.cs
+++ b/ValheimVRMod/Scripts/MainWeaponCollision.cs
@@ -21,6 +21,20 @@ namespace ValheimVRMod.Scripts {
         public PhysicsEstimator mainHandPhysicsEstimator { get { return weaponWield.mainHand == VRPlayer.leftHand ? VRPlayer.leftHandPhysicsEstimator : VRPlayer.rightHandPhysicsEstimator; } }
         public float twoHandedMultitargetSwipeCountdown { get; private set; } = 0;
 
+        protected override bool isAttackAvailable(GameObject target)
+        {
+            if (Player.m_localPlayer.m_blocking && !weaponWield.allowBlocking() && VHVRConfig.BlockingType() == "GrabButton")
+            {
+                return false;
+            }
+
+            if (ButtonSecondaryAttackManager.firstPos != Vector3.zero || ButtonSecondaryAttackManager.isSecondaryAttackStarted)
+            {
+                return false;
+            }
+
+            return base.isAttackAvailable(target);
+        }
 
         protected override Attack tryHitTarget(AttackTargetMeshCooldown attackTargetMeshCooldown) {
             bool isSecondaryAttack = postSecondaryAttackCountdown <= 0 && RoomscaleSecondaryAttackUtils.IsSecondaryAttack(this.physicsEstimator, this.mainHandPhysicsEstimator);
@@ -80,6 +94,18 @@ namespace ValheimVRMod.Scripts {
             }
 
             return false;
+        }
+
+        private void FixedUpdate()
+        {
+            if (postSecondaryAttackCountdown > 0)
+            {
+                postSecondaryAttackCountdown -= Time.fixedDeltaTime;
+            }
+            if (twoHandedMultitargetSwipeCountdown > 0)
+            {
+                postSecondaryAttackCountdown -= Time.fixedDeltaTime;
+            }
         }
 
         private bool isStab()

--- a/ValheimVRMod/Scripts/WeaponCollision.cs
+++ b/ValheimVRMod/Scripts/WeaponCollision.cs
@@ -24,7 +24,7 @@ namespace ValheimVRMod.Scripts {
         public PhysicsEstimator physicsEstimator { get; private set; }
         public bool itemIsTool;
         public static bool isDrinking;
-        public static bool isLastHitOnTerrain;
+        public bool isLastHitOnTerrain;
 
         private float colliderDistance;
 

--- a/ValheimVRMod/Scripts/WeaponCollision.cs
+++ b/ValheimVRMod/Scripts/WeaponCollision.cs
@@ -143,7 +143,7 @@ namespace ValheimVRMod.Scripts {
             }
         }
 
-        private bool isAttackAvailable(GameObject target) {
+        protected virtual bool isAttackAvailable(GameObject target) {
 
             // ignore certain Layers
             if (ignoreLayers.Contains(target.layer)) {

--- a/ValheimVRMod/Utilities/StaticObjects.cs
+++ b/ValheimVRMod/Utilities/StaticObjects.cs
@@ -6,8 +6,8 @@ using Object = UnityEngine.Object;
 namespace ValheimVRMod.Utilities {
     public static class StaticObjects {
         
-        private static WeaponCollision _leftWeaponCollider;
-        private static WeaponCollision _rightWeaponCollider;
+        private static MainWeaponCollision _leftWeaponCollider;
+        private static MainWeaponCollision _rightWeaponCollider;
         private static FistCollision _leftFist;
         private static FistCollision _rightFist;
         public static GameObject leftHandQuickMenu;
@@ -19,11 +19,11 @@ namespace ValheimVRMod.Utilities {
         public static Vector3 lastHitDir;
         public static Collider lastHitCollider;
         
-        public static WeaponCollision leftWeaponCollider() {
+        public static MainWeaponCollision leftWeaponCollider() {
             return getCollisionScriptCube(ref _leftWeaponCollider);
         }
         
-        public static WeaponCollision rightWeaponCollider() {
+        public static MainWeaponCollision rightWeaponCollider() {
             return getCollisionScriptCube(ref _rightWeaponCollider);
         }
         


### PR DESCRIPTION
Refactor WeaponCollision to a base class that does not depend on WeaponWield and does not support secondary attack or atgeir swipe and a subclass that has all the current functions. The base class may be used for left hand torch attack.